### PR TITLE
Restore legacy browser change events and expose state values

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ Turn a normal `checkbox` input into a tristate input.
 >	Either get or set the state of the checkbox. Uses `true` for checked,
 	`false` for unchecked or `null` for indeterminate state.
 
+-	`getChecked`, `getUnchecked`, `getIndeterminate`
+
+>	Return the configured value for the corresponding state without changing the
+	current state. If no state-specific value was configured, these methods return
+	the checkbox's normal `value` attribute.
+
 -	`value`
 
 >	Get the current value or set the state by specifying the value.

--- a/jquery.tristate.js
+++ b/jquery.tristate.js
@@ -44,15 +44,18 @@
 			var that = this,
 				state;
 
-			// Fix for #1
-			if (window.navigator.userAgent.indexOf('Trident') >= 0) {
-				this.element.click(function(e) {
-					that._change.call(that, e);			
-					that.element.closest('form').change();
-				});
-			} else {
-				this.element.change(function(e) {
-					that._change.call(that, e);
+			this.element.change(function(e) {
+				that._change.call(that, e);
+			});
+
+			// IE and legacy Edge clear the native indeterminate property before
+			// dispatching change. Re-emit change when leaving that state so both
+			// the plugin and application listeners observe the transition.
+			if (/(Trident|Edge)\//.test(window.navigator.userAgent)) {
+				this.element.click(function() {
+					if (!this.indeterminate && $(this).attr('indeterminate')) {
+						$(this).trigger('change');
+					}
 				});
 			}
 
@@ -128,6 +131,18 @@
 			} else if (value === this.settings.indeterminate) {
 				return null;
 			}
+		},
+
+		getChecked: function() {
+			return typeof this.settings.checked === 'undefined' ? this.element.attr('value') : this.settings.checked;
+		},
+
+		getUnchecked: function() {
+			return typeof this.settings.unchecked === 'undefined' ? this.element.attr('value') : this.settings.unchecked;
+		},
+
+		getIndeterminate: function() {
+			return typeof this.settings.indeterminate === 'undefined' ? this.element.attr('value') : this.settings.indeterminate;
 		},
 
 		value: function(value) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -324,6 +324,32 @@ QUnit.jqui.tests({
 		equal(cb.tristate('state'),		false,	"Unchanged");
 	},
 
+	"Public value getters": function() {
+		'use strict';
+
+		var cb = $('<input type="checkbox" value="default"/>').appendTo('body');
+		cb.tristate({
+			checked:		'C',
+			unchecked:		'U',
+			indeterminate:	'I'
+		});
+
+		equal(cb.tristate('getChecked'),		'C',	"Checked value");
+		equal(cb.tristate('getUnchecked'),		'U',	"Unchecked value");
+		equal(cb.tristate('getIndeterminate'),	'I',	"Indeterminate value");
+	},
+
+	"Public value getters fall back to the input value": function() {
+		'use strict';
+
+		var cb = $('<input type="checkbox" value="default"/>').appendTo('body');
+		cb.tristate();
+
+		equal(cb.tristate('getChecked'),		'default',	"Checked fallback");
+		equal(cb.tristate('getUnchecked'),		'default',	"Unchecked fallback");
+		equal(cb.tristate('getIndeterminate'),	'default',	"Indeterminate fallback");
+	},
+
 	"Events": {
 		type:	'async',
 		test:	function() {


### PR DESCRIPTION
## What changed
- Restore the checkbox-level `change` handler for every browser.
- Reintroduce the indeterminate transition compatibility hook for Trident and extend it to legacy Edge.
- Add `getChecked`, `getUnchecked`, and `getIndeterminate` methods with tests and documentation.

## Why
The reverse-order change moved Trident onto a click-only path that triggered change on the form instead of the checkbox. Application listeners therefore missed the intermediate transition, while legacy Edge did not receive the compatibility behavior at all.

The getters implement the state-value API previously discussed in #7 without changing the current checkbox state.

Fixes #10.
Fixes #11.
Addresses #7.

## Validation
- Added QUnit coverage for configured values and native-value fallbacks.
- Exercised legacy Edge click transitions and input-level change listeners in an isolated jsdom integration harness.
- Ran syntax checks on the plugin and test source.