### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,5 +26,14 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Add QUnit compatibility shim
+        run: |
+          printf '%s\n' \
+            "var util = require('util');" \
+            "util.print = function () { process.stdout.write(Array.prototype.join.call(arguments, '')); };" \
+            > /tmp/qunit-compat.js
+
       - name: Run tests
         run: npm test
+        env:
+          NODE_OPTIONS: --require=/tmp/qunit-compat.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - 0.8
-  - 0.12
-  - 4.4
-  - 5.11
-  - 6.1
-before_script:
-  - npm install

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
 		"test": "node --harmony ./test/testrunner.js"
 	},
 	"devDependencies": {
-		"qunit": "*"
+		"qunit": "~0.5.18"
 	}
 }


### PR DESCRIPTION
## What changed
- Replace Travis CI with a GitHub Actions test workflow.
- Pin QUnit to the historical 0.5 runner expected by the committed test harness instead of resolving an incompatible current package.
- Add a CI-only `util.print()` compatibility shim for modern Node.js.
- Run the existing `npm test` command with read-only workflow permissions.

## Why
The Travis matrix targeted obsolete Node.js 0.x through 6.x releases. On current Node.js, the unbounded QUnit dependency resolves a different API, and the historical runner calls a removed Node utility method.

## Validation
The GitHub Actions workflow passes on Node.js 16.